### PR TITLE
Show state/LGA names instead of IDs in order details and notifications

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -246,7 +246,10 @@ class AdminController extends Controller
         }
 
         $order = Order::with(['user', 'car', 'payment', 'agent'])
-            ->where('slug', $slug)
+            ->leftJoin('states', 'orders.state', '=', 'states.id')
+            ->leftJoin('lgas', 'orders.lga', '=', 'lgas.id')
+            ->select('orders.*', 'states.state_name as state_name', 'lgas.lga_name as lga_name')
+            ->where('orders.slug', $slug)
             ->first();
 
         if (!$order) {
@@ -488,6 +491,13 @@ class AdminController extends Controller
     private function notifyAgent($order, $agent)
     {
         try {
+            // Get state and LGA names
+            $state = \App\Models\State::find($order->state);
+            $lga = \App\Models\Lga::find($order->lga);
+            
+            $stateName = $state ? $state->state_name : 'Unknown State';
+            $lgaName = $lga ? $lga->lga_name : 'Unknown LGA';
+            
             // WhatsApp notification (placeholder - you'd integrate with WhatsApp API)
             $whatsappMessage = "New Order Assigned!\n\n";
             $whatsappMessage .= "Order ID: {$order->slug}\n";
@@ -496,14 +506,16 @@ class AdminController extends Controller
             $whatsappMessage .= "Amount: ₦{$order->amount}\n";
             $whatsappMessage .= "Address: {$order->delivery_address}\n";
             $whatsappMessage .= "Contact: {$order->delivery_contact}\n";
-            $whatsappMessage .= "State: {$order->state}\n";
-            $whatsappMessage .= "LGA: {$order->lga}\n";
+            $whatsappMessage .= "State: {$stateName}\n";
+            $whatsappMessage .= "LGA: {$lgaName}\n";
 
             // Email notification
             $emailData = [
                 'agent' => $agent,
                 'order' => $order,
-                'whatsapp_message' => $whatsappMessage
+                'whatsapp_message' => $whatsappMessage,
+                'stateName' => $stateName,
+                'lgaName' => $lgaName
             ];
 
             Mail::send('emails.agent-order-notification', $emailData, function ($message) use ($agent, $order) {

--- a/resources/views/emails/agent-order-notification.blade.php
+++ b/resources/views/emails/agent-order-notification.blade.php
@@ -98,11 +98,11 @@
             </div>
             <div class="detail-row">
                 <span class="detail-label">State:</span>
-                <span class="detail-value">{{ $order->state }}</span>
+                <span class="detail-value">{{ $stateName ?? 'Unknown State' }}</span>
             </div>
             <div class="detail-row">
                 <span class="detail-label">LGA:</span>
-                <span class="detail-value">{{ $order->lga }}</span>
+                <span class="detail-value">{{ $lgaName ?? 'Unknown LGA' }}</span>
             </div>
             @if($order->notes)
             <div class="detail-row">


### PR DESCRIPTION
- Fix order details display from IDs to readable names